### PR TITLE
feat: set limit for num of contacts to select

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ protected void onActivityResult(int requestCode, int resultCode, Intent data) {
 
 The source code includes a more comprehensive example.<br>Also check out the demo app on Google Play: https://play.google.com/store/apps/details?id=com.onegravity.contactpicker.demo.
 
+####**Intent Extra Parameters**
+
+As seen above in the example, these parameters are chained to the intent where each param descriptor is attached to `ContactPickerActivity`. 
+Below is a listing of the parameters and their purpose:
+
+| Parameter  | Description  |
+|---|:---|
+|  **EXTRA_SELECT_CONTACTS_LIMIT** (int)  |  This parameter will limit the amount of contacts that can be selected per intent. When set to zero, then no limiting will be enforced <br/> Default: `0` |
+|  **EXTRA_LIMIT_REACHED_MESSAGE** (String)  |  This parameter sets the text displayed as a toast when the set limit is reached <br/> Default: `You have reached the limit!` |
+|  **EXTRA_SHOW_CHECK_ALL** (Boolean)  |  This parameter decides whether to show/hide the check_all button in the menu. When `EXTRA_SELECT_CONTACTS_LIMIT` > 0, this will be forced to `false`.  <br/> Default: `true` |
+|  **EXTRA_ONLY_CONTACTS_WITH_PHONE** (Boolean)  |  This parameter sets the boolean that filters contacts that have no phone numbers <br/> Default: `false` |
+
 ####**Theming**
 
 The library supports a dark and a light theme out-of-the-box. In order to do that, it defines a

--- a/demo/src/main/java/com/onegravity/contactpicker/demo/DemoActivity.java
+++ b/demo/src/main/java/com/onegravity/contactpicker/demo/DemoActivity.java
@@ -87,6 +87,9 @@ public class DemoActivity extends BaseActivity {
 
                             .putExtra(ContactPickerActivity.EXTRA_CONTACT_DESCRIPTION,
                                       ContactDescription.ADDRESS.name())
+                            .putExtra(ContactPickerActivity.EXTRA_SHOW_CHECK_ALL, true)
+                            .putExtra(ContactPickerActivity.EXTRA_SELECT_CONTACTS_LIMIT, 0)
+                            .putExtra(ContactPickerActivity.EXTRA_ONLY_CONTACTS_WITH_PHONE, false)
 
                             .putExtra(ContactPickerActivity.EXTRA_CONTACT_DESCRIPTION_TYPE,
                                       ContactsContract.CommonDataKinds.Email.TYPE_WORK)


### PR DESCRIPTION
- create limit params for selecting contacts
- update readme with documentation
- add param to filter contacts without phone numbers

see updated readme: https://github.com/lwhiteley/Android-ContactPicker/

resolves #6 

**Behaviour Designed:**
- A limit parameter was created that defaults to `0`
- when greater than zero it will hide the select all button (even if, `EXTRA_SHOW_CHECK_ALL` is set to `true`)
- if limit is greater than `0`, once you have selected that number of contacts, you cannot select other contacts
- A configurable toast msg will appear when limit has reached and the user tries to select more contacts
- For groups that exceed the limit, this toast will appear,
- For groups that are under the limit, but are selected in combination with others that accumulate over the limit, a toast will appear and selection disabled as well. Eg. below shows a limit of 6 and a user trying to select two groups that exceed the limit


![Screen Shot 2016-10-24 at 7.55.22 AM](http://i.imgur.com/wSPkPIP.png?2)