### PR TITLE
App unfortunately stops issue resolved

### DIFF
--- a/library/src/main/java/com/onegravity/contactpicker/contact/ContactAdapter.java
+++ b/library/src/main/java/com/onegravity/contactpicker/contact/ContactAdapter.java
@@ -60,7 +60,8 @@ public class ContactAdapter extends RecyclerView.Adapter<ContactViewHolder> impl
     public void setData(List<? extends Contact> contacts) {
         mContacts = contacts;
         notifyDataSetChanged();
-        calculateSections();
+        if(mContacts.size()>0)
+            calculateSections();
     }
 
     @Override


### PR DESCRIPTION
Stops when there are no results in recycler view or the adapter is empty ..
Suppose in search bar I entered a random query whose value doesn't exist in recycler view . Since the adapter don't have any list or it's is null...While touching your fast scroll the app unfortunately stops. I know the issue if of the fast scroll library and i have also created issue there for the same but for now it has to be handled.